### PR TITLE
fix: $_SESSION in-scope after ?lti-blog=true (#11)

### DIFF
--- a/classes/class-ed-lti.php
+++ b/classes/class-ed-lti.php
@@ -91,6 +91,7 @@ class Ed_LTI {
 	 */
 	public function do_launch(): void {
 		if ( $this->is_basic_lti_request() ) {
+			session_start();
 			$launch = LTI\LTI_Message_Launch::new( new ED_Example_Database( $_SESSION['client_id'] ) )->validate();
 			$data   = $launch->get_launch_data();
 			$this->destroy_session();


### PR DESCRIPTION
Bring $_session('client-id') into scope, to prevent failure of the database lookup.